### PR TITLE
Add device routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake', '~> 10.4.2'
-gem 'sinatra', '~> 1.4.5'
+gem 'sinatra', git: 'https://github.com/sinatra/sinatra'
 gem 'activerecord', '~> 4.2.0'
 gem 'unicorn', '~> 4.8.3'
 gem 'sqlite3', '~> 1.3.10'

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ group :development, :test do
   gem 'rubocop', '~> 0.28.0'
   gem 'rack-test', '~> 0.6.3'
   gem 'database_cleaner', '~> 1.4.0'
+  gem 'factory_girl', '~> 4.5.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,8 @@ GEM
     coderay (1.1.0)
     database_cleaner (1.4.0)
     diff-lcs (1.2.5)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
     i18n (0.7.0)
     json (1.8.2)
     kgio (2.9.3)
@@ -85,6 +87,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 4.2.0)
   database_cleaner (~> 1.4.0)
+  factory_girl (~> 4.5.0)
   pry (~> 0.10.1)
   rack-test (~> 0.6.3)
   rake (~> 10.4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/sinatra/sinatra
+  revision: 27d1716c7388db9f3c07d07c8b0c3c285d5caf42
+  specs:
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -63,17 +72,13 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.7.1)
-    sinatra (1.4.5)
-      rack (~> 1.4)
-      rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
     sinatra-activerecord (2.0.4)
       activerecord (>= 3.2)
       sinatra (~> 1.0)
     slop (3.6.0)
     sqlite3 (1.3.10)
     thread_safe (0.3.4)
-    tilt (1.4.1)
+    tilt (2.0.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unicorn (4.8.3)
@@ -93,7 +98,7 @@ DEPENDENCIES
   rake (~> 10.4.2)
   rspec (~> 3.1.0)
   rubocop (~> 0.28.0)
-  sinatra (~> 1.4.5)
+  sinatra!
   sinatra-activerecord (~> 2.0.4)
   sqlite3 (~> 1.3.10)
   unicorn (~> 4.8.3)

--- a/Rakefile
+++ b/Rakefile
@@ -31,5 +31,13 @@ task shell: :environment do
   Pry.start
 end
 
+desc 'Run the web server'
+task web: :environment do
+  ENV['RACK_ENV'] = ENV['APP_ENV']
+  unicorn_conf = { config_file: 'unicorn.rb' }
+  app = Unicorn.builder('config.ru', unicorn_conf)
+  Unicorn::HttpServer.new(app, unicorn_conf).start.join
+end
+
 desc 'Run the specs and quality metrics'
 task default: [:spec, :quality]

--- a/app/cappy.rb
+++ b/app/cappy.rb
@@ -3,6 +3,7 @@ Bundler.require(:default, (ENV['APP_ENV'] || 'development').to_sym)
 # This module acts as the top-level namespace for the application.
 module Cappy
   autoload :Controllers, 'cappy/controllers'
+  autoload :Errors, 'cappy/errors'
   autoload :Models, 'cappy/models'
   autoload :Services, 'cappy/services'
 

--- a/app/cappy/controllers.rb
+++ b/app/cappy/controllers.rb
@@ -2,6 +2,8 @@ module Cappy
   # This module holds all of the controllers (which are sinatra applications)
   # for the application.
   module Controllers
+    autoload :Base, 'cappy/controllers/base'
+    autoload :Devices, 'cappy/controllers/devices'
     autoload :Version, 'cappy/controllers/version'
   end
 end

--- a/app/cappy/controllers.rb
+++ b/app/cappy/controllers.rb
@@ -1,6 +1,6 @@
 module Cappy
-  # This module all of the controllers (which are sinatra applications) for the
-  # application.
+  # This module holds all of the controllers (which are sinatra applications)
+  # for the application.
   module Controllers
     autoload :Version, 'cappy/controllers/version'
   end

--- a/app/cappy/controllers/base.rb
+++ b/app/cappy/controllers/base.rb
@@ -1,0 +1,37 @@
+module Cappy
+  module Controllers
+    # This controller doesn't expose any routes, but is used as a base for the
+    # rest of the application's controllers.
+    class Base < Sinatra::Base
+      set :raise_errors, false
+      set :show_exceptions, false
+
+      before { content_type :json }
+
+      error do |err|
+        case err
+        when Errors::MalformedRequestError, Errors::BadDeviceOptions
+          status 400
+        when Errors::NoSuchDevice
+          status 404
+        when Errors::DuplicationError
+          status 409
+        else
+          status 500
+        end
+
+        { class: err.class, message: err.message }.to_json
+      end
+
+      def parse_json(body)
+        JSON.parse(body)
+      rescue JSON::JSONError => ex
+        raise Errors::MalformedRequestError, ex
+      end
+
+      def req_body
+        request.body.tap(&:rewind).string
+      end
+    end
+  end
+end

--- a/app/cappy/controllers/devices.rb
+++ b/app/cappy/controllers/devices.rb
@@ -19,7 +19,7 @@ module Cappy
       end
 
       put '/devices/:device_id/' do |device_id|
-        status 204
+        status 200
         Services::Devices.update(device_id, parse_json(req_body)).to_json
       end
 

--- a/app/cappy/controllers/devices.rb
+++ b/app/cappy/controllers/devices.rb
@@ -1,0 +1,32 @@
+module Cappy
+  module Controllers
+    # This controller returns Cappy's version. It can be used on deploys as a
+    # live-check URL.
+    class Devices < Base
+      get '/devices/' do
+        status 200
+        Services::Devices.list.to_json
+      end
+
+      post '/devices/' do
+        status 201
+        Services::Devices.create(parse_json(req_body)).to_json
+      end
+
+      get '/devices/:device_id/' do |device_id|
+        status 200
+        Services::Devices.read(device_id).to_json
+      end
+
+      put '/devices/:device_id/' do |device_id|
+        status 204
+        Services::Devices.update(device_id, parse_json(req_body)).to_json
+      end
+
+      delete '/devices/:device_id/' do |device_id|
+        status 204
+        Services::Devices.destroy(device_id)
+      end
+    end
+  end
+end

--- a/app/cappy/controllers/version.rb
+++ b/app/cappy/controllers/version.rb
@@ -2,9 +2,9 @@ module Cappy
   module Controllers
     # This controller returns Cappy's version. It can be used on deploys as a
     # live-check URL.
-    class Version < Sinatra::Base
+    class Version < Base
       get '/version' do
-        [200, Cappy::VERSION]
+        [200, { version: Cappy::VERSION }.to_json]
       end
     end
   end

--- a/app/cappy/errors.rb
+++ b/app/cappy/errors.rb
@@ -1,0 +1,10 @@
+module Cappy
+  # This module contains all of the application specific errors.
+  module Errors
+    # Never raised, but useful as an application-specific catch-all.
+    BaseError = Class.new(::StandardError)
+
+    # Raised when an unknown device_id is referenced.
+    NoSuchDevice = Class.new(BaseError)
+  end
+end

--- a/app/cappy/errors.rb
+++ b/app/cappy/errors.rb
@@ -6,5 +6,8 @@ module Cappy
 
     # Raised when an unknown device_id is referenced.
     NoSuchDevice = Class.new(BaseError)
+
+    # Raised when bad attributes are passed to create or update a device.
+    BadDeviceOptions = Class.new(BaseError)
   end
 end

--- a/app/cappy/errors.rb
+++ b/app/cappy/errors.rb
@@ -9,5 +9,11 @@ module Cappy
 
     # Raised when bad attributes are passed to create or update a device.
     BadDeviceOptions = Class.new(BaseError)
+
+    # Raised when a request cannot be parsed.
+    MalformedRequestError = Class.new(BaseError)
+
+    # Raised when duplicated data is created.
+    DuplicationError = Class.new(BaseError)
   end
 end

--- a/app/cappy/models.rb
+++ b/app/cappy/models.rb
@@ -1,5 +1,5 @@
 module Cappy
-  # This module all of the ActiveRecord models used by Cappy.
+  # This module holds all of the ActiveRecord models used by Cappy.
   module Models
     autoload :Device, 'cappy/models/device'
   end

--- a/app/cappy/models/device.rb
+++ b/app/cappy/models/device.rb
@@ -5,9 +5,9 @@ module Cappy
       self.table_name = 'devices'
       VALID_DEVICE_TYPES = %w(lock outlet gas_valve airbourne_alert)
 
-      validates :device_id,     presence: true
-      validates :name,          presence: true
-      validates :device_type,   presence: true, inclusion: { in: VALID_DEVICE_TYPES }
+      validates :device_id, presence: true
+      validates :name, presence: true
+      validates :device_type, presence: true, inclusion: { in: VALID_DEVICE_TYPES }
     end
   end
 end

--- a/app/cappy/models/device.rb
+++ b/app/cappy/models/device.rb
@@ -8,6 +8,14 @@ module Cappy
       validates :device_id, presence: true
       validates :name, presence: true
       validates :device_type, presence: true, inclusion: { in: VALID_DEVICE_TYPES }
+
+      def as_json(*args)
+        super.dup.tap do |hash|
+          hash.delete('created_at')
+          hash.delete('updated_at')
+          hash['last_check_in'] = last_check_in.utc.iso8601 if last_check_in.present?
+        end
+      end
     end
   end
 end

--- a/app/cappy/services.rb
+++ b/app/cappy/services.rb
@@ -1,6 +1,6 @@
 module Cappy
-  # This module all of the services Cappy.
-  module Controllers
-    autoload :Version, 'cappy/controllers/version'
+  # This module holds all of the services Cappy.
+  module Services
+    autoload :Devices, 'cappy/services/devices'
   end
 end

--- a/app/cappy/services/devices.rb
+++ b/app/cappy/services/devices.rb
@@ -1,0 +1,48 @@
+module Cappy
+  module Services
+    # This service handles converting JSON data to/from database models for the
+    # devices table. Also, database level errors are wrapped into application-
+    # specific errors to make better use of HTTP errors codes in each
+    # controller.
+    module Devices
+      module_function
+
+      def list
+        Models::Device.all.map(&:as_json)
+      end
+
+      def create(data)
+        wrap_active_record_errors do
+          Models::Device.create!(data)
+        end
+      end
+
+      def read(device_id)
+        get_device(device_id).as_json
+      end
+
+      def update(device_id, data)
+        wrap_active_record_errors do
+          device = get_device(device_id)
+          device.update_attributes!(data)
+        end
+      end
+
+      def destroy(device_id)
+        get_device(device_id).destroy
+      end
+
+      def get_device(device_id)
+        Models::Device.find_by(device_id: device_id).tap do |device|
+          fail Errors::NoSuchDevice, device_id unless device
+        end
+      end
+
+      def wrap_active_record_errors(&block)
+        block.call
+      rescue ActiveRecord::UnknownAttributeError, ActiveRecord::RecordInvalid => ex
+        raise Errors::BadDeviceOptions, ex
+      end
+    end
+  end
+end

--- a/app/cappy/services/devices.rb
+++ b/app/cappy/services/devices.rb
@@ -40,8 +40,8 @@ module Cappy
         end
       end
 
-      def wrap_active_record_errors(&block)
-        block.call
+      def wrap_active_record_errors
+        yield
       rescue ActiveRecord::UnknownAttributeError, ActiveRecord::RecordInvalid => ex
         raise Errors::BadDeviceOptions, ex
       end

--- a/app/cappy/services/devices.rb
+++ b/app/cappy/services/devices.rb
@@ -12,9 +12,11 @@ module Cappy
       end
 
       def create(data)
-        wrap_active_record_errors do
-          Models::Device.create!(data)
+        if Models::Device.exists?(device_id: data['device_id'])
+          fail Errors::DuplicationError, "Device already exists with id: #{data['device_id']}"
         end
+
+        wrap_active_record_errors { Models::Device.create!(data) }
       end
 
       def read(device_id)

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,4 @@
+constants = Cappy::Controllers.constants.map(&Cappy::Controllers.method(:const_get))
+controllers = constants.select { |const| const.is_a?(Class) && (const < Sinatra::Base) }
+run Rack::Cascade.new(controllers)
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150127200131) do
+ActiveRecord::Schema.define(version: 20150125183018) do
 
   create_table "devices", force: :cascade do |t|
     t.string   "device_id",     null: false

--- a/spec/app/cappy/controllers/devices_spec.rb
+++ b/spec/app/cappy/controllers/devices_spec.rb
@@ -108,7 +108,7 @@ describe Cappy::Controllers::Devices do
         it 'updates that device' do
           put "/devices/#{device.device_id}/", { name: 'Kitchen' }.to_json
 
-          expect(last_response.status).to eq(204)
+          expect(last_response.status).to eq(200)
         end
       end
     end

--- a/spec/app/cappy/controllers/devices_spec.rb
+++ b/spec/app/cappy/controllers/devices_spec.rb
@@ -1,0 +1,139 @@
+require 'spec_helper'
+require 'pry'
+
+describe Cappy::Controllers::Devices do
+  include Rack::Test::Methods
+
+  let(:app) { described_class.new }
+
+  describe 'GET /devices/' do
+    let(:device_one) { build(:lock) }
+    let(:device_two) { build(:gas_valve) }
+    let(:devices) { [device_one, device_two].sort_by(&:id)  }
+
+    before { devices.each(&:save!) }
+
+    it 'returns a list of every device' do
+      get '/devices/'
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.headers['Content-Type']).to eq('application/json')
+      expect(JSON.parse(last_response.body).sort_by { |hash| hash['id'] }).to eq(devices.as_json)
+    end
+  end
+
+  describe 'POST /devices/' do
+    context 'when invalid data is POSTed' do
+      let(:hash) { { goo_goo: 'ga_ga' } }
+
+      it 'returns a "400 Client Error"' do
+        post '/devices/', hash.to_json
+
+        expect(last_response.status).to eq(400)
+      end
+    end
+
+    context 'when valid data is POSTed' do
+      context 'but that device already exists' do
+        let(:device) { create(:lock) }
+        let(:json) { device.as_json.tap { |hash| hash.delete('id') }.to_json }
+
+        it 'returns a "409 Conflict"' do
+          post '/devices/', json
+
+          expect(last_response.status).to eq(409)
+        end
+      end
+
+      context 'and that device does not exist' do
+        let(:device) { build(:gas_valve) }
+        let(:json) { device.to_json }
+
+        it 'returns a "201 Created"' do
+          post '/devices/', json
+
+          expect(last_response.status).to eq(201)
+          expect(JSON.parse(last_response.body)['device_id']).to eq(device.device_id)
+        end
+      end
+    end
+  end
+
+  describe 'GET /devices/DEVICE_ID/' do
+    context 'when the DEVICE_ID does not exist' do
+      it 'returns a "404 Not Found"' do
+        get '/devices/does_not_exist/'
+
+        expect(last_response.status).to eq(404)
+      end
+    end
+
+    context 'when the DEVICE_ID exists' do
+      let(:device) { build(:airbourne_alert) }
+
+      before { device.save! }
+
+      it 'returns that device' do
+        get "/devices/#{device.device_id}/"
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)).to eq(device.as_json)
+      end
+    end
+  end
+
+  describe 'PUT /devices/DEVICE_ID/' do
+    context 'when the DEVICE_ID does not exist' do
+      it 'returns a "404 Not Found"' do
+        put '/devices/does_not_exist', { name: 'Kitchen' }.to_json
+
+        expect(last_response.status).to eq(404)
+      end
+    end
+
+    context 'when the DEVICE_ID exists' do
+      let(:device) { build(:outlet) }
+
+      before { device.save! }
+
+      context 'but invalid data is PUT' do
+        it 'returns a "400 Client Error"' do
+          put "/devices/#{device.device_id}/", { age: 'Kitchen' }.to_json
+
+          expect(last_response.status).to eq(400)
+        end
+      end
+
+      context 'and valid data is PUT' do
+        it 'updates that device' do
+          put "/devices/#{device.device_id}/", { name: 'Kitchen' }.to_json
+
+          expect(last_response.status).to eq(204)
+        end
+      end
+    end
+  end
+
+  describe 'DELETE /devices/DEVICE_ID/' do
+    context 'when the DEVICE_ID does not exist' do
+      it 'returns a "404 Not Found"' do
+        delete '/devices/does_not_exist/'
+
+        expect(last_response.status).to eq(404)
+      end
+    end
+
+    context 'when the DEVICE_ID exists' do
+      let(:device) { create(:lock) }
+      let(:device_id) { device.device_id }
+
+      it 'deletes that device' do
+        delete "/devices/#{device_id}/"
+
+        expect(last_response.status).to eq(204)
+        expect { Cappy::Services::Devices.read(device_id) }
+          .to raise_error(Cappy::Errors::NoSuchDevice)
+      end
+    end
+  end
+end

--- a/spec/app/cappy/controllers/version_spec.rb
+++ b/spec/app/cappy/controllers/version_spec.rb
@@ -10,7 +10,7 @@ describe Cappy::Controllers::Version do
       get '/version'
 
       expect(last_response.status).to eq(200)
-      expect(last_response.body).to eq(Cappy::VERSION)
+      expect(JSON.parse(last_response.body)).to eq('version' => Cappy::VERSION)
     end
   end
 end

--- a/spec/app/cappy/models/device_spec.rb
+++ b/spec/app/cappy/models/device_spec.rb
@@ -8,13 +8,13 @@ describe Cappy::Models::Device do
     let(:device_type)   { 'lock' }
     let(:last_check_in) { DateTime.now }
 
-    valid_types = %w( lock outlet gas_valve airbourne_alert )
-
     subject do
-      described_class.new(device_id: device_id,
-                          name: name,
-                          device_type: device_type,
-                          last_check_in: last_check_in)
+      described_class.new(
+        device_id: device_id,
+        name: name,
+        device_type: device_type,
+        last_check_in: last_check_in
+      )
     end
 
     context 'when the device_id is nil' do
@@ -53,8 +53,8 @@ describe Cappy::Models::Device do
           end
 
           context 'and the device_type is a valid value' do
-            valid_types.each do |d_t|
-              let(:device_type) { d_t }
+            Cappy::Models::Device::VALID_DEVICE_TYPES.each do |type|
+              let(:device_type) { type }
 
               it 'is valid' do
                 expect(subject).to be_valid

--- a/spec/app/cappy/services/devices_spec.rb
+++ b/spec/app/cappy/services/devices_spec.rb
@@ -1,0 +1,129 @@
+require 'spec_helper'
+
+describe Cappy::Services::Devices do
+  describe '#list' do
+    let(:device_one) { build(:lock) }
+    let(:device_two) { build(:gas_valve) }
+    let(:devices) { [device_one, device_two] }
+
+    before { devices.each(&:save!) }
+
+    it 'returns a list of all of the devices' do
+      expect(subject.list).to eq(devices.map(&:as_json))
+    end
+  end
+
+  describe '#create' do
+    context 'when an invalid key is passed' do
+      let(:valid_hash) { build(:outlet).as_json }
+      let(:invalid_hash) { valid_hash.tap { |hash| hash[:test] = true } }
+
+      it 'raises an error' do
+        expect { subject.create(invalid_hash) }
+          .to raise_error(Cappy::Errors::BadDeviceOptions)
+      end
+    end
+
+    context 'when not enough keys are passed' do
+      let(:valid_hash) { build(:airbourne_alert).as_json }
+      let(:invalid_hash) { valid_hash.tap { |hash| hash.delete('name') } }
+
+      it 'raises an error' do
+        expect { subject.create(invalid_hash) }
+          .to raise_error(Cappy::Errors::BadDeviceOptions)
+      end
+    end
+
+    context 'when some of the keys reference invalid data' do
+      let(:valid_hash) { build(:lock).as_json }
+      let(:invalid_hash) { valid_hash.tap { |hash| hash['device_type'] = 'LOCK' } }
+
+      it 'raises an error' do
+        expect { subject.create(invalid_hash) }
+          .to raise_error(Cappy::Errors::BadDeviceOptions)
+      end
+    end
+
+    context 'when all of the keys and values are valid' do
+      let(:valid_hash) { build(:gas_valve).as_json }
+      let(:including_hash) { valid_hash.reject { |_, v| v.nil? }.to_h }
+
+      it 'adds a new device' do
+        subject.create(valid_hash)
+        expect(subject.list).to match([a_hash_including(including_hash)])
+      end
+    end
+  end
+
+  describe '#read' do
+    context 'when there is no device with the given id' do
+      it 'raises an error' do
+        expect { subject.read('anything') }
+          .to raise_error(Cappy::Errors::NoSuchDevice)
+      end
+    end
+
+    context 'when there is a device with the given id' do
+      let(:device) { build(:lock) }
+
+      before { device.save! }
+
+      it 'returns the device' do
+        expect(subject.read(device.device_id)).to eq(device.as_json)
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'when the given device id cannot be found' do
+      it 'raises an error' do
+        expect { subject.update('anything', name: 'Kitchen') }
+          .to raise_error(Cappy::Errors::NoSuchDevice)
+      end
+    end
+
+    context 'when the given device id can be found' do
+      let(:device) { build(:gas_valve) }
+
+      before { device.save! }
+
+      context 'but the data is invalid' do
+        it 'raises an error' do
+          expect { subject.update(device.device_id, device_type: 'stove') }
+            .to raise_error(Cappy::Errors::BadDeviceOptions)
+        end
+      end
+
+      context 'and the data is valid' do
+        let(:name) { 'stove' }
+
+        it 'updates the device' do
+          subject.update(device.device_id, name: name)
+          expect(subject.read(device.device_id)['name']).to eq(name)
+        end
+      end
+    end
+  end
+
+  describe '.destroy' do
+    context 'when the given device id does not exist' do
+      it 'raises an error' do
+        expect { subject.destroy('anything') }
+          .to raise_error(Cappy::Errors::NoSuchDevice)
+      end
+    end
+
+    context 'when the given device id exists' do
+      let(:device) { build(:lock) }
+      let(:device_id) { device.device_id }
+
+      before { device.save! }
+
+      it 'removes that device from the database' do
+        subject.destroy(device_id)
+        expect { subject.read(device_id) }
+          .to raise_error(Cappy::Errors::NoSuchDevice)
+      end
+    end
+  end
+end

--- a/spec/app/cappy/services/devices_spec.rb
+++ b/spec/app/cappy/services/devices_spec.rb
@@ -44,6 +44,17 @@ describe Cappy::Services::Devices do
       end
     end
 
+    context 'when there already exists a Device with that device id' do
+      let(:valid_hash) { build(:lock).as_json }
+
+      before { subject.create(valid_hash) }
+
+      it 'raises an error' do
+        expect { subject.create(valid_hash) }
+          .to raise_error(Cappy::Errors::DuplicationError)
+      end
+    end
+
     context 'when all of the keys and values are valid' do
       let(:valid_hash) { build(:gas_valve).as_json }
       let(:including_hash) { valid_hash.reject { |_, v| v.nil? }.to_h }

--- a/spec/factories/devices_factory.rb
+++ b/spec/factories/devices_factory.rb
@@ -1,0 +1,12 @@
+# Build a factory for each device type
+
+Cappy::Models::Device::VALID_DEVICE_TYPES.each do |device_type|
+  FactoryGirl.define do
+    factory device_type, class: Cappy::Models::Device do
+      sequence(:device_id) { |n| "DEVICE-#{n}" }
+      sequence(:name) { |n| "NAME-#{n}" }
+      device_type device_type
+      last_check_in { Time.now }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,15 @@ Bundler.require(:default, ENV['APP_ENV'].to_sym)
 
 require 'cappy'
 
+Dir['spec/factories/**/*.rb'].each { |factory| load(factory) }
+
 RSpec.configure do |config|
+  config.include(FactoryGirl::Syntax::Methods)
+
   config.before(:suite) do
     DatabaseCleaner.strategy = :truncation
     DatabaseCleaner.clean_with(:truncation)
+    FactoryGirl.lint
   end
 
   config.around(:each) do |example|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,10 +13,9 @@ RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.strategy = :truncation
     DatabaseCleaner.clean_with(:truncation)
-    FactoryGirl.lint
   end
 
   config.around(:each) do |example|
-    DatabaseCleaner.cleaning(&example.method(:run))
+    DatabaseCleaner.cleaning { example.run }
   end
 end

--- a/unicorn.rb
+++ b/unicorn.rb
@@ -1,0 +1,18 @@
+# Set the application directory
+APP_DIR = File.expand_path(File.dirname(__FILE__))
+TMP_DIR = File.join('/', 'tmp')
+SOCKET_PATH = File.join(TMP_DIR, 'unicorn.sock')
+PID_PATH = File.join(TMP_DIR, 'unicorn.pid')
+
+working_directory APP_DIR
+timeout 30
+
+pid PID_PATH
+
+if %w(staging production).include?(ENV['RACK_ENV'])
+  listen SOCKET_PATH, backlog: 64
+  preload_app true
+  user 'nobody'
+else
+  listen 4567, backlog: 64
+end

--- a/unicorn.rb
+++ b/unicorn.rb
@@ -1,18 +1,11 @@
 # Set the application directory
 APP_DIR = File.expand_path(File.dirname(__FILE__))
-TMP_DIR = File.join('/', 'tmp')
-SOCKET_PATH = File.join(TMP_DIR, 'unicorn.sock')
-PID_PATH = File.join(TMP_DIR, 'unicorn.pid')
+APP_PORT = (ENV['APP_PORT'] || 4567).to_i
+PID_PATH = File.join(Dir.tmpdir, 'unicorn.pid')
 
-working_directory APP_DIR
 timeout 30
-
+working_directory APP_DIR
 pid PID_PATH
-
-if %w(staging production).include?(ENV['RACK_ENV'])
-  listen SOCKET_PATH, backlog: 64
-  preload_app true
-  user 'nobody'
-else
-  listen 4567, backlog: 64
-end
+listen APP_PORT, backlog: 64
+preload_app true
+user 'nobody'


### PR DESCRIPTION
@djosborne Add RESTful routes for the frontend.

@Daniel0524 @AdamEdgett I recommend you guys take a peek at the [controller spec](https://github.com/cappity-cappity-capstone/backend/blob/eaabcaf5a3a710d8dbd8612cd57290be1a0a48c0/spec/app/cappy/controllers/devices_spec.rb) to get a sense for the HTTP status codes/responses I went with. For a tl;dr, here's the spec output

```
Cappy::Controllers::Devices
  GET /devices/
    returns a list of every device
  POST /devices/
    when invalid data is POSTed
      returns a "400 Client Error"
    when valid data is POSTed
      but that device already exists
        returns a "409 Conflict"
      and that device does not exist
        returns a "201 Created"
  GET /devices/DEVICE_ID/
    when the DEVICE_ID does not exist
      returns a "404 Not Found"
    when the DEVICE_ID exists
      returns that device
  PUT /devices/DEVICE_ID/
    when the DEVICE_ID does not exist
      returns a "404 Not Found"
    when the DEVICE_ID exists
      but invalid data is PUT
        returns a "400 Client Error"
      and valid data is PUT
        updates that device
  DELETE /devices/DEVICE_ID/
    when the DEVICE_ID does not exist
      returns a "404 Not Found"
    when the DEVICE_ID exists
      deletes that device
```

When not specified, the HTTP status is either `200` or `204`