### PR TITLE
Suss out scheduling

### DIFF
--- a/app/cappy.rb
+++ b/app/cappy.rb
@@ -1,4 +1,5 @@
 require 'socket'
+require 'set'
 Bundler.require(:default, (ENV['APP_ENV'] || 'development').to_sym)
 
 # This module acts as the top-level namespace for the application.

--- a/app/cappy/controllers.rb
+++ b/app/cappy/controllers.rb
@@ -7,6 +7,7 @@ module Cappy
     autoload :States, 'cappy/controllers/states'
     autoload :Broadcast, 'cappy/controllers/broadcast'
     autoload :Schedules, 'cappy/controllers/schedules'
+    autoload :Tasks, 'cappy/controllers/tasks'
     autoload :Version, 'cappy/controllers/version'
   end
 end

--- a/app/cappy/controllers/schedules.rb
+++ b/app/cappy/controllers/schedules.rb
@@ -12,10 +12,15 @@ module Cappy
         Services::Schedules.for_device(device_id).to_json
       end
 
-      post '/schedules/:device_id/?' do |device_id|
+      get '/tasks/:task_id/schedules/?' do |task_id|
+        status 200
+        Services::Schedules.for_task(task_id).to_json
+      end
+
+      post '/schedules/:task_id/?' do |task_id|
         status 201
-        device = Services::Devices.get_device(device_id)
-        Services::Schedules.create(device, parse_json(req_body)).to_json
+        task = Services::Tasks.get_task(task_id)
+        Services::Schedules.create(task, parse_json(req_body)).to_json
       end
 
       get '/schedules/:schedule_id/?' do |schedule_id|

--- a/app/cappy/controllers/tasks.rb
+++ b/app/cappy/controllers/tasks.rb
@@ -1,0 +1,37 @@
+module Cappy
+  module Controllers
+    # This controller handles CRUD operations for schedules
+    class Tasks < Base
+      get '/tasks/?' do
+        status 200
+        Services::Tasks.list.to_json
+      end
+
+      get '/devices/:device_id/tasks/?' do |device_id|
+        status 200
+        Services::Tasks.for_device(device_id).to_json
+      end
+
+      post '/tasks/:device_id/?' do |device_id|
+        status 201
+        device = Services::Devices.get_device(device_id)
+        Services::Tasks.create(device, parse_json(req_body)).to_json
+      end
+
+      get '/tasks/:tasks_id/?' do |tasks_id|
+        status 200
+        Services::Tasks.read(tasks_id).to_json
+      end
+
+      put '/tasks/:tasks_id/?' do |tasks_id|
+        status 200
+        Services::Tasks.update(tasks_id, parse_json(req_body)).to_json
+      end
+
+      delete '/tasks/:tasks_id/?' do |tasks_id|
+        status 204
+        Services::Tasks.destroy(tasks_id)
+      end
+    end
+  end
+end

--- a/app/cappy/models.rb
+++ b/app/cappy/models.rb
@@ -3,6 +3,8 @@ module Cappy
   module Models
     autoload :Device, 'cappy/models/device'
     autoload :State, 'cappy/models/state'
+    autoload :Task, 'cappy/models/task'
     autoload :Schedule, 'cappy/models/schedule'
+    autoload :TaskComplete, 'cappy/models/task_complete'
   end
 end

--- a/app/cappy/models/device.rb
+++ b/app/cappy/models/device.rb
@@ -6,7 +6,8 @@ module Cappy
       VALID_DEVICE_TYPES = %w(lock outlet gas_valve airbourne_alert)
 
       has_many :states
-      has_many :schedules
+      has_many :tasks
+      has_many :schedules, through: :tasks
 
       validates :device_id, presence: true
       validates :name, presence: true

--- a/app/cappy/models/schedule.rb
+++ b/app/cappy/models/schedule.rb
@@ -1,10 +1,10 @@
 module Cappy
   module Models
-    # This model represents a schedule for a device
+    # This model represents a schedule for a task
     class Schedule < ActiveRecord::Base
       self.table_name = 'schedules'
 
-      belongs_to :device
+      belongs_to :task
 
       validates :start_time, presence: true
       validates :interval, presence: true

--- a/app/cappy/models/schedule.rb
+++ b/app/cappy/models/schedule.rb
@@ -15,6 +15,10 @@ module Cappy
           hash['end_time'] = end_time.utc.iso8601 if end_time.present?
         end
       end
+
+      def self.not_expired(time)
+        where('end_time > ? OR end_time IS NULL', time)
+      end
     end
   end
 end

--- a/app/cappy/models/state.rb
+++ b/app/cappy/models/state.rb
@@ -3,7 +3,11 @@ module Cappy
     # This model represents the state of a connected device
     class State < ActiveRecord::Base
       self.table_name = 'states'
-      VALID_SOURCES = %w(scheduled parent_left manual_override)
+      SCHEDULED = 'scheduled'
+      PARENT_LEFT = 'parent_left'
+      MANUAL_OVERRIDE = 'manual_override'
+
+      VALID_SOURCES = [SCHEDULED, PARENT_LEFT, MANUAL_OVERRIDE]
 
       default_scope { order('created_at ASC') }
 

--- a/app/cappy/models/task.rb
+++ b/app/cappy/models/task.rb
@@ -5,6 +5,7 @@ module Cappy
       self.table_name = 'tasks'
 
       belongs_to :device
+      has_many :schedules
 
       validates :state, presence: true
     end

--- a/app/cappy/models/task.rb
+++ b/app/cappy/models/task.rb
@@ -1,0 +1,12 @@
+module Cappy
+  module Models
+    # This model represents a task for a device
+    class Task < ActiveRecord::Base
+      self.table_name = 'tasks'
+
+      belongs_to :device
+
+      validates :state, presence: true
+    end
+  end
+end

--- a/app/cappy/models/task.rb
+++ b/app/cappy/models/task.rb
@@ -8,6 +8,12 @@ module Cappy
       has_many :schedules
 
       validates :state, presence: true
+
+      def as_json(*args)
+        super.dup.tap do |hash|
+          hash['state'] = state.to_s('F')
+        end
+      end
     end
   end
 end

--- a/app/cappy/models/task_complete.rb
+++ b/app/cappy/models/task_complete.rb
@@ -1,0 +1,12 @@
+module Cappy
+  module Models
+    # Maintains the record of the last time tasks were run
+    class TaskComplete < ActiveRecord::Base
+      self.table_name = 'task_complete'
+
+      def self.starting_point
+        new(created_at: Time.mktime(0))
+      end
+    end
+  end
+end

--- a/app/cappy/services.rb
+++ b/app/cappy/services.rb
@@ -6,5 +6,6 @@ module Cappy
     autoload :States, 'cappy/services/states'
     autoload :Broadcast, 'cappy/services/broadcast'
     autoload :Schedules, 'cappy/services/schedules'
+    autoload :Tasks, 'cappy/services/tasks'
   end
 end

--- a/app/cappy/services.rb
+++ b/app/cappy/services.rb
@@ -6,6 +6,7 @@ module Cappy
     autoload :States, 'cappy/services/states'
     autoload :Broadcast, 'cappy/services/broadcast'
     autoload :Schedules, 'cappy/services/schedules'
+    autoload :Tasks, 'cappy/services/tasks'
     autoload :TaskRunner, 'cappy/services/task_runner'
   end
 end

--- a/app/cappy/services.rb
+++ b/app/cappy/services.rb
@@ -6,6 +6,6 @@ module Cappy
     autoload :States, 'cappy/services/states'
     autoload :Broadcast, 'cappy/services/broadcast'
     autoload :Schedules, 'cappy/services/schedules'
-    autoload :Tasks, 'cappy/services/tasks'
+    autoload :TaskRunner, 'cappy/services/task_runner'
   end
 end

--- a/app/cappy/services/schedules.rb
+++ b/app/cappy/services/schedules.rb
@@ -1,6 +1,6 @@
 module Cappy
   module Services
-    # This service handles converting JSON data to/from database models for the
+    # This service handles converting JSON data to database models for the
     # schedules table. Also, database level errors are wrapped into application-
     # specific errors to make better use of HTTP errors codes in each
     # controller.
@@ -10,26 +10,32 @@ module Cappy
       module_function
 
       def list
-        Models::Schedule.all.map(&:as_json)
+        Models::Schedule.all
       end
 
       def for_device(device_id = nil)
         device = Services::Devices.get_device(device_id)
-        device.schedules.all.map(&:as_json)
+        device.schedules.all
       end
 
-      def create(device, data)
-        wrap_active_record_errors { device.schedules.create!(data) }
+      def for_task(task_id = nil)
+        task = Services::Tasks.get_task(task_id)
+        task.schedules.all
+      end
+
+      def create(task, data)
+        wrap_active_record_errors { task.schedules.create!(data) }
       end
 
       def read(schedule_id)
-        get_schedule(schedule_id).as_json
+        get_schedule(schedule_id)
       end
 
       def update(schedule_id, data)
         wrap_active_record_errors do
-          schedule = get_schedule(schedule_id)
-          schedule.update_attributes!(data)
+          get_schedule(schedule_id).tap do |schedule|
+            schedule.update_attributes!(data)
+          end
         end
       end
 

--- a/app/cappy/services/task_runner.rb
+++ b/app/cappy/services/task_runner.rb
@@ -22,20 +22,20 @@ module Cappy
       def tasks(last_task_time, this_task_time)
         unique_tasks = Set.new
 
-        Models::Schedule.all.each do |schedule|
-          unique_task << schedule_within_time_range?(schedule, last_task_time, this_task_time)
+        Models::Schedule.not_expired(this_task_time).each do |schedule|
+          unique_tasks << schedule_within_time_range?(schedule, last_task_time, this_task_time)
         end
 
-        unique_tasks.compat
+        unique_tasks.to_a.compact
       end
 
       def schedule_within_time_range?(schedule, last_time, this_time)
         if schedule.interval > 0
           last_multiple = multiple_for_time_and_schedule(last_time, schedule)
           this_multiple = multiple_for_time_and_schedule(this_time, schedule)
-          schedule.task if last_multiple < this_multiple
+          schedule.task if last_multiple < this_multiple && this_multiple >= 0
         else
-          if last_task_time < schedule.start_time && schedule.start_time < this_task_time
+          if last_time < schedule.start_time && schedule.start_time <= this_time
             schedule.task
           end
         end

--- a/app/cappy/services/task_runner.rb
+++ b/app/cappy/services/task_runner.rb
@@ -1,7 +1,7 @@
 module Cappy
   module Services
-    # This module handles performing tasks when they need to be performed
-    module Tasks
+    # This module handles running tasks when they need to be performed
+    module TaskRunner
       @queue = :cappy
 
       module_function

--- a/app/cappy/services/task_runner.rb
+++ b/app/cappy/services/task_runner.rb
@@ -14,7 +14,7 @@ module Cappy
         tasks(previous.created_at, now.created_at).each do |task|
           task.device.states << Models::State.create(
             state: task.state,
-            source: 'scheduled'
+            source: Cappy::Models::State::SCHEDULED
           )
         end
       end

--- a/app/cappy/services/task_runner.rb
+++ b/app/cappy/services/task_runner.rb
@@ -23,20 +23,26 @@ module Cappy
         unique_tasks = Set.new
 
         Models::Schedule.all.each do |schedule|
-          if schedule.interval > 0
-            last_interval_multiple = ((last_task_time - schedule.start_time) / schedule.interval).floor
-            this_interval_multiple = ((this_task_time - schedule.start_time) / schedule.interval).floor
-            if last_interval_multiple < this_interval_multiple
-              unique_tasks << schedule.task
-            end
-          else
-            if last_task_time < schedule.start_time && schedule.start_time < this_task_time
-              unique_tasks << schedule.task
-            end
-          end
+          unique_task << schedule_within_time_range?(schedule, last_task_time, this_task_time)
         end
 
-        unique_tasks
+        unique_tasks.compat
+      end
+
+      def schedule_within_time_range?(schedule, last_time, this_time)
+        if schedule.interval > 0
+          last_multiple = multiple_for_time_and_schedule(last_time, schedule)
+          this_multiple = multiple_for_time_and_schedule(this_time, schedule)
+          schedule.task if last_multiple < this_multiple
+        else
+          if last_task_time < schedule.start_time && schedule.start_time < this_task_time
+            schedule.task
+          end
+        end
+      end
+
+      def multiple_for_time_and_schedule(time, schedule)
+        ((time - schedule.start_time) / schedule.interval).floor
       end
 
       def last_completed

--- a/app/cappy/services/tasks.rb
+++ b/app/cappy/services/tasks.rb
@@ -1,0 +1,47 @@
+module Cappy
+  module Services
+    # This module handles performing tasks when they need to be performed
+    module Tasks
+      @queue = :cappy
+
+      module_function
+
+      def perform
+        previous = last_completed
+        # Cutoff for tasks
+        now = Models::TaskComplete.create
+
+        tasks(previous.created_at, now.created_at).each do |task|
+          task.device.states << Models::State.create(
+            state: task.state,
+            source: 'scheduled'
+          )
+        end
+      end
+
+      def tasks(last_task_time, this_task_time)
+        unique_tasks = Set.new
+
+        Models::Schedule.all.each do |schedule|
+          if schedule.interval > 0
+            last_interval_multiple = ((last_task_time - schedule.start_time) / schedule.interval).floor
+            this_interval_multiple = ((this_task_time - schedule.start_time) / schedule.interval).floor
+            if last_interval_multiple < this_interval_multiple
+              unique_tasks << schedule.task
+            end
+          else
+            if last_task_time < schedule.start_time && schedule.start_time < this_task_time
+              unique_tasks << schedule.task
+            end
+          end
+        end
+
+        unique_tasks
+      end
+
+      def last_completed
+        Models::TaskComplete.last || Models::TaskComplete.starting_point
+      end
+    end
+  end
+end

--- a/app/cappy/services/tasks.rb
+++ b/app/cappy/services/tasks.rb
@@ -1,0 +1,48 @@
+module Cappy
+  module Services
+    # This service handles converting JSON data to database models for the
+    # tasks table. Also, database level errors are wrapped into application-
+    # specific errors to make better use of HTTP errors codes in each
+    # controller.
+    module Tasks
+      include Base
+
+      module_function
+
+      def list
+        Models::Task.all
+      end
+
+      def for_device(device_id = nil)
+        device = Services::Devices.get_device(device_id)
+        device.tasks.all
+      end
+
+      def create(device, data)
+        wrap_active_record_errors { device.tasks.create!(data) }
+      end
+
+      def read(task_id)
+        get_task(task_id)
+      end
+
+      def update(task_id, data)
+        wrap_active_record_errors do
+          get_task(task_id).tap do |task|
+            task.update_attributes!(data)
+          end
+        end
+      end
+
+      def destroy(task_id)
+        get_task(task_id).destroy
+      end
+
+      def get_task(task_id)
+        Models::Task.find_by(id: task_id).tap do |task|
+          fail Errors::NoSuchObject, task_id unless task
+        end
+      end
+    end
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -5,4 +5,6 @@ module Clockwork
 
   # Sample
   every 10.seconds, Cappy::Services::Broadcast
+
+  every 1.minute, Cappy::Services::Tasks
 end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -6,5 +6,5 @@ module Clockwork
   # Sample
   every 10.seconds, Cappy::Services::Broadcast
 
-  every 1.minute, Cappy::Services::Tasks
+  every 1.minute, Cappy::Services::TaskRunner
 end

--- a/db/migrate/20150228124100_add_task_for_schedules.rb
+++ b/db/migrate/20150228124100_add_task_for_schedules.rb
@@ -1,0 +1,11 @@
+class AddTaskForSchedules < ActiveRecord::Migration
+  def change
+    create_table :tasks do |t|
+      t.integer :device_id, null: false
+      t.decimal :state, null: false
+    end
+
+    remove_column :schedules, :device_id
+    add_column :schedules, :task_id, :integer
+  end
+end

--- a/db/migrate/20150228210433_create_task_completed.rb
+++ b/db/migrate/20150228210433_create_task_completed.rb
@@ -1,0 +1,7 @@
+class CreateTaskCompleted < ActiveRecord::Migration
+  def change
+    create_table :task_complete do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150207093600) do
+ActiveRecord::Schema.define(version: 20150228210433) do
 
   create_table "devices", force: :cascade do |t|
     t.string   "device_id",     null: false
@@ -26,10 +26,10 @@ ActiveRecord::Schema.define(version: 20150207093600) do
   add_index "devices", ["device_id"], name: "index_devices_on_device_id"
 
   create_table "schedules", force: :cascade do |t|
-    t.integer  "device_id",  null: false
     t.datetime "start_time", null: false
     t.datetime "end_time"
     t.integer  "interval",   null: false
+    t.integer  "task_id"
   end
 
   create_table "states", force: :cascade do |t|
@@ -41,5 +41,15 @@ ActiveRecord::Schema.define(version: 20150207093600) do
   end
 
   add_index "states", ["device_id"], name: "index_states_on_device_id"
+
+  create_table "task_complete", force: :cascade do |t|
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "tasks", force: :cascade do |t|
+    t.integer "device_id", null: false
+    t.decimal "state",     null: false
+  end
 
 end

--- a/spec/app/cappy/controllers/tasks_spec.rb
+++ b/spec/app/cappy/controllers/tasks_spec.rb
@@ -1,0 +1,146 @@
+require 'spec_helper'
+
+describe Cappy::Controllers::Tasks do
+  include Rack::Test::Methods
+
+  let(:app) { described_class.new }
+  let(:device_one) { create(:lock) }
+  let(:device_two) { create(:outlet) }
+
+  describe 'GET /tasks/' do
+    let(:task_one) { build(:task, device: device_one) }
+    let(:task_two) { build(:task, device: device_two) }
+    let(:tasks) { [task_one, task_two].sort_by(&:id) }
+
+    before { tasks.each(&:save!) }
+
+    it 'returns a list of every task' do
+      get '/tasks/'
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.headers['Content-Type']).to eq('application/json')
+      expect(JSON.parse(last_response.body).sort_by { |hash| hash['id'] })
+        .to eq(tasks.map(&:as_json))
+    end
+  end
+
+  describe 'GET /devices/DEVICE_ID/tasks/' do
+    let(:task_one) { build(:task, device: device_one) }
+    let(:task_two) { build(:task, device: device_two) }
+    let(:tasks) { [task_one, task_two].sort_by(&:id) }
+
+    before { tasks.each(&:save!) }
+
+    it 'returns a list of every task' do
+      get "/devices/#{device_one.device_id}/tasks/"
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.headers['Content-Type']).to eq('application/json')
+      expect(JSON.parse(last_response.body)[0]).to eq(task_one.as_json)
+    end
+  end
+
+  describe 'POST /tasks/DEVICE_ID' do
+    context 'when invalid data is POSTed' do
+      let(:hash) { { goo_goo: 'ga_ga' } }
+
+      it 'returns a "400 Client Error"' do
+        post "/tasks/#{device_one.device_id}/", hash.to_json
+
+        expect(last_response.status).to eq(400)
+      end
+    end
+
+    context 'when valid data is POSTed' do
+      let(:task) { build(:task) }
+      let(:json) { task.to_json }
+      let(:body) { JSON.parse(last_response.body) }
+
+      it 'returns a "201 Created"' do
+        post "/tasks/#{device_one.device_id}/", json
+
+        expect(last_response.status).to eq(201)
+        expect(body['state']).to eq(task.state.to_s('F'))
+        expect(body['device_id']).to eq(device_one.id)
+      end
+    end
+  end
+
+  describe 'GET /tasks/TASK_ID/' do
+    context 'when the TASK_ID does not exist' do
+      it 'returns a "404 Not Found"' do
+        get '/tasks/does_not_exist/'
+
+        expect(last_response.status).to eq(404)
+      end
+    end
+
+    context 'when the TASK_ID exists' do
+      let(:task) { build(:task, device: device_one) }
+
+      before { task.save! }
+
+      it 'returns that task' do
+        get "/tasks/#{task.id}/"
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)).to eq(task.as_json)
+      end
+    end
+  end
+
+  describe 'PUT /tasks/TASK_ID/' do
+    context 'when the TASK_ID does not exist' do
+      it 'returns a "404 Not Found"' do
+        put '/tasks/does_not_exist', { start_time: Time.now }.to_json
+
+        expect(last_response.status).to eq(404)
+      end
+    end
+
+    context 'when the TASK_ID exists' do
+      let(:task) { build(:task, device: device_one) }
+
+      before { task.save! }
+
+      context 'but invalid data is PUT' do
+        it 'returns a "400 Client Error"' do
+          put "/tasks/#{task.id}/", { age: 'Kitchen' }.to_json
+
+          expect(last_response.status).to eq(400)
+        end
+      end
+
+      context 'and valid data is PUT' do
+        it 'updates that task' do
+          put "/tasks/#{task.id}/", { state: 1.0 }.to_json
+
+          expect(last_response.status).to eq(200)
+        end
+      end
+    end
+  end
+
+  describe 'DELETE /tasks/TASK_ID/' do
+    context 'when the TASK_ID does not exist' do
+      it 'returns a "404 Not Found"' do
+        delete '/tasks/does_not_exist/'
+
+        expect(last_response.status).to eq(404)
+      end
+    end
+
+    context 'when the TASK_ID exists' do
+      let(:task) { create(:task, device: device_one) }
+      let(:task_id) { task.id }
+
+      it 'deletes that task' do
+        delete "/tasks/#{task_id}/"
+
+        expect(last_response.status).to eq(204)
+        expect { Cappy::Services::Tasks.read(task_id) }
+          .to raise_error(Cappy::Errors::NoSuchObject)
+      end
+    end
+  end
+end

--- a/spec/app/cappy/models/schedule_spec.rb
+++ b/spec/app/cappy/models/schedule_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Cappy::Models::Schedule do
+  describe '.not_expired' do
+    let(:cutoff) { Time.new(2015, 02, 28, 10, 00, 00) }
+
+    let!(:schedule_one) do
+      create(:schedule, :hourly,
+             start_time: Time.mktime(0),
+             end_time: cutoff - 1.hour)
+    end
+    let!(:schedule_two) do
+      create(:schedule, :hourly,
+             start_time: Time.mktime(0),
+             end_time: cutoff + 1.hour)
+    end
+    let!(:schedule_three) do
+      create(:schedule, :hourly,
+             start_time: Time.mktime(0))
+    end
+
+    it 'returns schedule two and three' do
+      expect(described_class.not_expired(cutoff)).to eq([schedule_two, schedule_three])
+    end
+  end
+end

--- a/spec/app/cappy/services/task_runner_spec.rb
+++ b/spec/app/cappy/services/task_runner_spec.rb
@@ -1,0 +1,222 @@
+require 'spec_helper'
+
+describe Cappy::Services::TaskRunner do
+  describe '.perform' do
+    let(:device) { create(:lock) }
+    let(:task) { create(:task, device: device) }
+    let!(:schedule) do
+      create(
+        :schedule_ends_immediately,
+        start_time: Time.new(2015, 2, 28, 17, 40, 00),
+        task: task
+      )
+    end
+
+    it 'makes a new task complete and runs the tasks' do
+      expect do
+        described_class.perform
+      end.to change { Cappy::Models::TaskComplete.count }.by(1)
+        .and change { device.states.count }.by(1)
+    end
+  end
+
+  describe '.tasks' do
+    shared_examples 'tasks within a timerange' do
+      it do
+        expect(
+          described_class.tasks(last_time, this_time)
+        ).to eq(expected)
+      end
+    end
+
+    let(:start_time) { Time.new(2015, 2, 28, 10, 00, 00) }
+    let(:end_time) { Time.new(2015, 2, 28, 11, 00, 00) }
+    let(:device) { create(:outlet) }
+    let(:task) { create(:task, device: device) }
+    let!(:schedule) do
+      create(
+        :schedule, :minutely,
+        start_time: start_time,
+        end_time: end_time,
+        task: task
+      )
+    end
+
+    context 'when there are two schedules for the same task and both apply' do
+      let!(:schedule_two) do
+        create(
+          :schedule,
+          interval: 0,
+          start_time: start_time,
+          task: task
+        )
+      end
+      let(:last_time) { start_time - 1.minutes }
+      let(:this_time) { start_time + 1.minute }
+      let(:expected) { [task] }
+
+      it_behaves_like 'tasks within a timerange'
+    end
+
+    context 'when the start time has not been crossed' do
+      let(:last_time) { start_time - 2.minutes }
+      let(:this_time) { start_time - 1.minutes }
+      let(:expected) { [] }
+
+      it_behaves_like 'tasks within a timerange'
+    end
+
+    context 'when the start time is now' do
+      let(:last_time) { start_time - 1.minutes }
+      let(:this_time) { start_time }
+      let(:expected) { [task] }
+
+      it_behaves_like 'tasks within a timerange'
+    end
+
+    context 'when the start time is before now and the end time is after' do
+      let(:last_time) { start_time }
+      let(:this_time) { start_time + 1.minute }
+      let(:expected) { [task] }
+
+      it_behaves_like 'tasks within a timerange'
+    end
+
+    context 'when the start time is before now and the end time is now' do
+      let(:last_time) { end_time - 1.minute }
+      let(:this_time) { end_time }
+      let(:expected) { [] }
+
+      it_behaves_like 'tasks within a timerange'
+    end
+
+    context 'when the start time is before now and the end time is before now' do
+      let(:last_time) { end_time }
+      let(:this_time) { end_time + 1.minute }
+      let(:expected) { [] }
+
+      it_behaves_like 'tasks within a timerange'
+    end
+  end
+
+  describe '.schedule_within_time_range?' do
+    let(:task) { build(:task) }
+    let(:last_time) { Time.new(2015, 2, 28,  9, 59, 00) }
+    let(:this_time) { Time.new(2015, 2, 28, 10, 00, 00) }
+    subject do
+      described_class.schedule_within_time_range?(
+        schedule, last_time, this_time
+      )
+    end
+
+    context 'with a schedule that runs more than once' do
+      context 'and starts at the same second' do
+        let(:schedule) { build(:schedule, :minutely, start_time: this_time, task: task) }
+
+        it 'returns the task' do
+          expect(subject).to eq(task)
+        end
+      end
+
+      context 'and starts a second later' do
+        let(:schedule) { build(:schedule, :minutely, start_time: this_time + 1, task: task) }
+
+        it 'returns nil' do
+          expect(subject).to be_nil
+        end
+      end
+    end
+
+    context 'with a schedule that runs only once' do
+      context 'and starts at the last time' do
+        let(:schedule) { build(:schedule_ends_immediately, start_time: last_time, task: task) }
+
+        it 'returns nil' do
+          expect(subject).to be_nil
+        end
+      end
+
+      context 'and starts at the same second' do
+        let(:schedule) { build(:schedule_ends_immediately, start_time: this_time, task: task) }
+
+        it 'returns the task' do
+          expect(subject).to eq(task)
+        end
+      end
+
+      context 'and starts a second later' do
+        let(:schedule) { build(:schedule_ends_immediately, start_time: this_time + 1, task: task) }
+
+        it 'returns nil' do
+          expect(subject).to be_nil
+        end
+      end
+    end
+  end
+
+  describe '.multiple_for_time_and_schedule' do
+    let(:time) { Time.new(2015, 02, 28, 10, 00, 00) }
+    subject { described_class.multiple_for_time_and_schedule(time, schedule) }
+
+    context 'an hour later' do
+      let(:schedule) { build(:schedule, :hourly, start_time: time - 1.hour) }
+
+      it do
+        expect(subject).to eq(1)
+      end
+    end
+
+    context 'an hour before' do
+      let(:schedule) { build(:schedule, :hourly, start_time: time + 1.hour) }
+
+      it do
+        expect(subject).to eq(-1)
+      end
+    end
+
+    context 'a second before' do
+      let(:schedule) { build(:schedule, :hourly, start_time: time + 1) }
+
+      it do
+        expect(subject).to eq(-1)
+      end
+    end
+
+    context 'the same second' do
+      let(:schedule) { build(:schedule, :hourly, start_time: time) }
+
+      it do
+        expect(subject).to eq(0)
+      end
+    end
+
+    context '59 minutes and 59 seconds after' do
+      let(:schedule) { build(:schedule, :hourly, start_time: time - (59.minutes + 59)) }
+
+      it do
+        expect(subject).to eq(0)
+      end
+    end
+  end
+
+  describe '.last_completed' do
+    context 'without a TaskComplete yet' do
+      before do
+        Cappy::Models::TaskComplete.all.each(&:destroy)
+      end
+
+      it 'uses starting_point' do
+        expect(Cappy::Models::TaskComplete).to receive(:starting_point)
+        subject.last_completed
+      end
+    end
+
+    context 'with a TaskComplete' do
+      let!(:task_complete) { Cappy::Models::TaskComplete.create }
+
+      it 'uses the last TaskComplete' do
+        expect(subject.last_completed).to eq(task_complete)
+      end
+    end
+  end
+end

--- a/spec/app/cappy/services/tasks_spec.rb
+++ b/spec/app/cappy/services/tasks_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+
+describe Cappy::Services::Tasks do
+  let(:device_one) { create(:lock) }
+  let(:device_two) { create(:outlet) }
+
+  describe '#list' do
+    let(:task_one) { build(:task, device: device_one) }
+    let(:task_two) { build(:task, device: device_two) }
+    let(:tasks) { [task_one, task_two] }
+
+    before { tasks.each(&:save!) }
+
+    context 'without a device' do
+      it 'returns a list of all of the tasks' do
+        expect(subject.list).to eq(tasks)
+      end
+    end
+  end
+
+  describe '#for_device' do
+    let(:task_one) { build(:task, device: device_one) }
+    let(:task_two) { build(:task, device: device_two) }
+    let(:tasks) { [task_one, task_two] }
+
+    before { tasks.each(&:save!) }
+
+    context 'with a device' do
+      it 'returns a list of all of the tasks' do
+        expect(subject.for_device(device_one.device_id)).to eq([task_one])
+      end
+    end
+  end
+
+  describe '#create' do
+    context 'when an invalid key is passed' do
+      let(:valid_hash) { build(:task).as_json }
+      let(:invalid_hash) { valid_hash.tap { |hash| hash[:test] = true } }
+
+      it 'raises an error' do
+        expect { subject.create(device_one, invalid_hash) }
+          .to raise_error(Cappy::Errors::BadOptions)
+      end
+    end
+
+    context 'when not enough keys are passed' do
+      let(:valid_hash) { build(:task).as_json }
+      let(:invalid_hash) { valid_hash.tap { |hash| hash.delete('state') } }
+
+      it 'raises an error' do
+        expect { subject.create(device_one, invalid_hash) }
+          .to raise_error(Cappy::Errors::BadOptions)
+      end
+    end
+
+    context 'when all of the keys and values are valid' do
+      let(:valid_hash) { build(:task).as_json }
+      let(:including_hash) { valid_hash.reject { |_, v| v.nil? }.to_h }
+
+      it 'adds a new device' do
+        subject.create(device_one, valid_hash)
+        expect(subject.list.as_json).to match([a_hash_including(including_hash)])
+      end
+    end
+  end
+
+  describe '#read' do
+    context 'when there is no task with the given id' do
+      it 'raises an error' do
+        expect { subject.read('anything') }
+          .to raise_error(Cappy::Errors::NoSuchObject)
+      end
+    end
+
+    context 'when there is a task with the given id' do
+      let(:task) { build(:task, device: device_one) }
+
+      before { task.save! }
+
+      it 'returns the task' do
+        expect(subject.read(task.id)).to eq(task)
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'when the given task id cannot be found' do
+      it 'raises an error' do
+        expect { subject.update('anything', state: 1) }
+          .to raise_error(Cappy::Errors::NoSuchObject)
+      end
+    end
+
+    context 'when the given task id can be found' do
+      let(:task) { build(:task, device: device_one) }
+
+      before { task.save! }
+
+      context 'but the data is invalid' do
+        it 'raises an error' do
+          expect { subject.update(task.id, task_type: 'stove') }
+            .to raise_error(Cappy::Errors::BadOptions)
+        end
+      end
+
+      context 'and the data is valid' do
+        let(:time) { Time.now }
+
+        it 'updates the task' do
+          subject.update(task.id, state: 1.0)
+          expect(subject.read(task.id)['state']).to eq(1.0)
+        end
+      end
+    end
+  end
+
+  describe '.destroy' do
+    context 'when the given task id does not exist' do
+      it 'raises an error' do
+        expect { subject.destroy('anything') }
+          .to raise_error(Cappy::Errors::NoSuchObject)
+      end
+    end
+
+    context 'when the given task id exists' do
+      let(:task) { build(:task, device: device_one) }
+
+      before { task.save! }
+
+      it 'removes that task from the database' do
+        subject.destroy(task.id)
+        expect { subject.read(task.id) }
+          .to raise_error(Cappy::Errors::NoSuchObject)
+      end
+    end
+  end
+end

--- a/spec/factories/schedules_factory.rb
+++ b/spec/factories/schedules_factory.rb
@@ -4,6 +4,10 @@ FactoryGirl.define do
       start_time { Time.now }
     end
 
+    trait :minutely do
+      interval 60
+    end
+
     trait :hourly do
       interval 60 * 60
     end
@@ -14,7 +18,6 @@ FactoryGirl.define do
 
     factory :schedule_ends_immediately do
       start_time { Time.now }
-      end_time { start_time }
       interval 0
     end
   end

--- a/spec/factories/tasks_factory.rb
+++ b/spec/factories/tasks_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :task, class: Cappy::Models::Task do
+    state 0
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH << File.expand_path('app', '.')
 ENV['APP_ENV'] ||= 'test'
+ENV['RACK_ENV'] ||= ENV['APP_ENV']
 
 Bundler.require(:default, ENV['APP_ENV'].to_sym)
 


### PR DESCRIPTION
@nahiluhmot @djosborne

Added a task model that has n schedules and belongs to a device.
Changed schedule to belong to a task instead of a device.
A task will set the state of a device to the designated state whenever one of it's schedules has been passed.

A schedule has a start time and optionally an interval and end time.
An interval > 0 will be periodic, and triggered every time an interval integer is crossed.
An interval <= 0 will be a single shot, and triggered once the start time has been passed.

The new state will have the source set to `scheduled`.

~~**NOTE**: I have not included tests yet.~~